### PR TITLE
Allow Multiple Token Field Names

### DIFF
--- a/Classes/Security/Authentication/Token/UsernamePasswordWithRememberMe.php
+++ b/Classes/Security/Authentication/Token/UsernamePasswordWithRememberMe.php
@@ -55,20 +55,24 @@ class UsernamePasswordWithRememberMe extends AbstractToken
 
         $arguments = $parentRequest->getArguments();
 
-        if (empty($this->settings['loginFormFields']['username']) || empty($this->settings['loginFormFields']['password'])) {
-            throw new \Neos\Flow\Configuration\Exception('You need to configure both username and password fields in CRON.RememberMe.loginFormFields');
+        foreach ($this->settings['loginFormFields'] as $loginFormFieldsSetting) {
+            if (empty($loginFormFieldsSetting['usaername']) || empty($loginFormFieldsSetting['password'])) {
+                throw new \Neos\Flow\Configuration\Exception('You need to configure both username and password fields in every entry of CRON.RememberMe.loginFormFields');
+            }
+
+            $username = trim(ObjectAccess::getPropertyPath($arguments, $loginFormFieldsSetting['username']));
+            $password = ObjectAccess::getPropertyPath($arguments, $loginFormFieldsSetting['password']);
+            $rememberMe = !empty($loginFormFieldsSetting['rememberMe']) ? ObjectAccess::getPropertyPath($arguments, $loginFormFieldsSetting['rememberMe']) : null;
+
+            if (!empty($username) && !empty($password)) {
+                $this->credentials['username'] = $username;
+                $this->credentials['password'] = $password;
+                $this->credentials['rememberMe'] = $rememberMe;
+                $this->setAuthenticationStatus(self::AUTHENTICATION_NEEDED);
+                break;
+            }
         }
 
-        $username = trim(ObjectAccess::getPropertyPath($arguments, $this->settings['loginFormFields']['username']));
-        $password = ObjectAccess::getPropertyPath($arguments, $this->settings['loginFormFields']['password']);
-        $rememberMe = ObjectAccess::getPropertyPath($arguments, $this->settings['loginFormFields']['rememberMe']);
-
-        if (!empty($username) && !empty($password)) {
-            $this->credentials['username'] = $username;
-            $this->credentials['password'] = $password;
-            $this->credentials['rememberMe'] = $rememberMe;
-            $this->setAuthenticationStatus(self::AUTHENTICATION_NEEDED);
-        }
         return true;
     }
 

--- a/Classes/Security/Authentication/Token/UsernamePasswordWithRememberMe.php
+++ b/Classes/Security/Authentication/Token/UsernamePasswordWithRememberMe.php
@@ -56,7 +56,7 @@ class UsernamePasswordWithRememberMe extends AbstractToken
         $arguments = $parentRequest->getArguments();
 
         foreach ($this->settings['loginFormFields'] as $loginFormFieldsSetting) {
-            if (empty($loginFormFieldsSetting['usaername']) || empty($loginFormFieldsSetting['password'])) {
+            if (empty($loginFormFieldsSetting['username']) || empty($loginFormFieldsSetting['password'])) {
                 throw new \Neos\Flow\Configuration\Exception('You need to configure both username and password fields in every entry of CRON.RememberMe.loginFormFields');
             }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,8 +8,9 @@ CRON:
     # used in CRON\RememberMe\Security\Authentication\Token\UsernamePasswordWithRememberMe.php.
     # Configure to use that token with your authentication provider.
     loginFormFields:
-      username: '__authentication.CRON.RememberMe.Security.Authentication.Token.UsernamePasswordWithRememberMe.username'
-      password: '__authentication.CRON.RememberMe.Security.Authentication.Token.UsernamePasswordWithRememberMe.password'
-      rememberMe: '__authentication.CRON.RememberMe.Security.Authentication.Token.UsernamePasswordWithRememberMe.rememberMe'
+      default:
+        username: '__authentication.CRON.RememberMe.Security.Authentication.Token.UsernamePasswordWithRememberMe.username'
+        password: '__authentication.CRON.RememberMe.Security.Authentication.Token.UsernamePasswordWithRememberMe.password'
+        rememberMe: '__authentication.CRON.RememberMe.Security.Authentication.Token.UsernamePasswordWithRememberMe.rememberMe'
     # Class name implementing RememberMeAuthenticationProcessorInterface. See interface for more information.
     rememberMeAuthenticationProcessorClassName: 'CRON\RememberMe\Security\Authentication\RememberMeAuthenticationProcessor'


### PR DESCRIPTION
This PR allows the configuration of multiple token field names for the UsernamePasswordWithRememberMe token, like:
```
CRON:
      RememberMe:
            loginPlugin:
                username: '--cron_davptaheute_user-content_loginplugin.login.emailAddress'
                password: '--cron_davptaheute_user-content_loginplugin.login.password'
                rememberMe: '--cron_davptaheute_user-content_loginplugin.login.rememberMe'
            purPlugin:
                username: '--cron_davptaheute_pur-content_purplugin.login.emailAddress'
                password: '--cron_davptaheute_pur-content_purplugin.login.password'
                rememberMe: '--cron_davptaheute_pur-content_purplugin.login.rememberMe'
```