### PR TITLE
Neos ^5.0 compatibility

### DIFF
--- a/Classes/Neos/AuthenticationEventsHandler.php
+++ b/Classes/Neos/AuthenticationEventsHandler.php
@@ -6,6 +6,7 @@ use Neos\Flow\Annotations as Flow;
 use Firebase\JWT\JWT as JwtService;
 use Neos\Flow\Http\Cookie;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Cryptography\HashService;
@@ -87,7 +88,7 @@ class AuthenticationEventsHandler
      */
     public function handleHTTPResponse($request, $response, $controller): void
     {
-        if ($request instanceof ActionRequest && $this->jwtCookie !== null) {
+        if ($this->jwtCookie !== null && $response instanceof ActionResponse) {
             $response->setCookie($this->jwtCookie);
         }
     }

--- a/Classes/Neos/AuthenticationEventsHandler.php
+++ b/Classes/Neos/AuthenticationEventsHandler.php
@@ -85,14 +85,13 @@ class AuthenticationEventsHandler
     /**
      * Inject the jwt cookie into the current http response if needed
      * @param RequestInterface $request
-     * @param ResponseInterface $response
+     * @param ActionResponse $response
      * @param ControllerInterface $controller
      */
-    public function handleHTTPResponse(RequestInterface $request, ResponseInterface $response, ControllerInterface $controller): void
+    public function handleHTTPResponse(RequestInterface $request, ActionResponse $response, ControllerInterface $controller): void
     {
-        if ($this->jwtCookie !== null && $response instanceof ActionResponse) {
-            $response->getHeaders()->setCookie($this->jwtCookie);
+        if ($this->jwtCookie !== null) {
+            $response->setCookie($this->jwtCookie);
         }
     }
-
 }

--- a/Classes/Neos/AuthenticationEventsHandler.php
+++ b/Classes/Neos/AuthenticationEventsHandler.php
@@ -4,13 +4,10 @@ namespace CRON\RememberMe\Neos;
 
 use Neos\Flow\Annotations as Flow;
 use Firebase\JWT\JWT as JwtService;
-use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Http\Cookie;
-use Neos\Flow\Http\HttpRequestHandlerInterface;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\ControllerInterface;
-use Neos\Flow\Mvc\RequestInterface;
-use Neos\Flow\Mvc\ResponseInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Cryptography\HashService;
@@ -84,11 +81,11 @@ class AuthenticationEventsHandler
 
     /**
      * Inject the jwt cookie into the current http response if needed
-     * @param RequestInterface $request
+     * @param ActionRequest $request
      * @param ActionResponse $response
      * @param ControllerInterface $controller
      */
-    public function handleHTTPResponse(RequestInterface $request, ActionResponse $response, ControllerInterface $controller): void
+    public function handleHTTPResponse(ActionRequest $request, ActionResponse $response, ControllerInterface $controller): void
     {
         if ($this->jwtCookie !== null) {
             $response->setCookie($this->jwtCookie);

--- a/Classes/Neos/AuthenticationEventsHandler.php
+++ b/Classes/Neos/AuthenticationEventsHandler.php
@@ -5,7 +5,6 @@ namespace CRON\RememberMe\Neos;
 use Neos\Flow\Annotations as Flow;
 use Firebase\JWT\JWT as JwtService;
 use Neos\Flow\Http\Cookie;
-use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;

--- a/Classes/Neos/AuthenticationEventsHandler.php
+++ b/Classes/Neos/AuthenticationEventsHandler.php
@@ -6,11 +6,10 @@ use Neos\Flow\Annotations as Flow;
 use Firebase\JWT\JWT as JwtService;
 use Neos\Flow\Http\Cookie;
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Mvc\ActionResponse;
-use Neos\Flow\Mvc\Controller\ControllerInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Cryptography\HashService;
+use Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException;
 
 /**
  * @Flow\Scope("singleton")
@@ -55,6 +54,7 @@ class AuthenticationEventsHandler
      * See Package.php
      *
      * @param TokenInterface $token
+     * @throws InvalidArgumentForHashGenerationException
      */
     public function authenticatedToken(TokenInterface $token): void
     {
@@ -81,13 +81,13 @@ class AuthenticationEventsHandler
 
     /**
      * Inject the jwt cookie into the current http response if needed
-     * @param ActionRequest $request
-     * @param ActionResponse $response
-     * @param ControllerInterface $controller
+     * @param mixed $request of type Neos\Flow\Mvc\ActionRequest when coming from a web request, but of type Neos\Flow\Cli\Request when coming from a command
+     * @param mixed $response of type Neos\Flow\Mvc\ActionResponse when coming from a web request, but of type Neos\Flow\Cli\Response when coming from a command
+     * @param mixed $controller of type Neos\Flow\Mvc\Controller\ControllerInterface when coming from a web request, but of type Neos\Flow\Command\ConfigurationCommandController when coming from a command
      */
-    public function handleHTTPResponse(ActionRequest $request, ActionResponse $response, ControllerInterface $controller): void
+    public function handleHTTPResponse($request, $response, $controller): void
     {
-        if ($this->jwtCookie !== null) {
+        if ($request instanceof ActionRequest && $this->jwtCookie !== null) {
             $response->setCookie($this->jwtCookie);
         }
     }

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -43,8 +43,13 @@ class Package extends BasePackage
         $dispatcher->connect(Dispatcher::class,
             'beforeControllerInvocation',
             AuthenticationEventsHandler::class,
-            'handleHTTPResponse'
+            'handleBeforeControllerInvocation'
         );
 
+        $dispatcher->connect(Dispatcher::class,
+            'afterControllerInvocation',
+            AuthenticationEventsHandler::class,
+            'handleAfterControllerInvocation'
+        );
     }
 }

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -5,14 +5,10 @@ namespace CRON\RememberMe;
 use Neos\Flow\Annotations as Flow;
 use CRON\RememberMe\Neos\AuthenticationEventsHandler;
 use Neos\Flow\Core\Bootstrap;
-use Neos\Flow\Mvc\Controller\ControllerInterface;
 use Neos\Flow\Mvc\Dispatcher;
-use Neos\Flow\Mvc\RequestInterface;
-use Neos\Flow\Mvc\ResponseInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Security\Authentication\AuthenticationProviderManager;
-use Neos\Flow\Security\Authentication\TokenInterface;
 
 class Package extends BasePackage
 {

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -41,7 +41,7 @@ class Package extends BasePackage
         );
 
         $dispatcher->connect(Dispatcher::class,
-            'afterControllerInvocation',
+            'beforeControllerInvocation',
             AuthenticationEventsHandler::class,
             'handleHTTPResponse'
         );

--- a/Classes/Security/Authentication/NeosRequestPattern.php
+++ b/Classes/Security/Authentication/NeosRequestPattern.php
@@ -33,15 +33,11 @@ class NeosRequestPattern implements RequestPatternInterface
     /**
      * Matches a \Neos\Flow\Mvc\RequestInterface against its set pattern rules
      *
-     * @param RequestInterface $request The request that should be matched
-     * @return boolean TRUE if the pattern matched, FALSE otherwise
+     * @param ActionRequest $request The request that should be matched
+     * @return bool TRUE if the pattern matched, FALSE otherwise
      */
-    public function matchRequest(RequestInterface $request)
+    public function matchRequest(ActionRequest $request): bool
     {
-        if (!$request instanceof ActionRequest) {
-            return false;
-        }
-
         $shouldMatchFrontend = isset($this->options['matchFrontend']) && $this->options['matchFrontend'] === true;
         $requestPath = $request->getHttpRequest()->getUri()->getPath();
         $requestPathMatchesBackend = strpos($requestPath, '/neos') === 0 || strpos($requestPath, '@') !== false;

--- a/Classes/Security/Authentication/RememberMeAuthenticationProcessor.php
+++ b/Classes/Security/Authentication/RememberMeAuthenticationProcessor.php
@@ -5,6 +5,7 @@ namespace CRON\RememberMe\Security\Authentication;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Authentication\TokenInterface;
+use Neos\Flow\Security\Exception\NoSuchRoleException;
 use Neos\Flow\Security\Policy\PolicyService;
 
 class RememberMeAuthenticationProcessor implements RememberMeAuthenticationProcessorInterface
@@ -15,6 +16,9 @@ class RememberMeAuthenticationProcessor implements RememberMeAuthenticationProce
      */
     protected $policyService;
 
+    /**
+     * @throws NoSuchRoleException
+     */
     public function process(Account $account, TokenInterface $token, array $data): void
     {
         if (isset($data['accountRoleIdentifiers'])) {

--- a/Classes/Security/Authentication/RememberMeProvider.php
+++ b/Classes/Security/Authentication/RememberMeProvider.php
@@ -2,6 +2,7 @@
 
 namespace CRON\RememberMe\Security\Authentication;
 
+use Exception;
 use Neos\Flow\Annotations as Flow;
 use CRON\RememberMe\Security\Authentication\Token\RememberMe;
 use Firebase\JWT\JWT as JwtService;
@@ -50,7 +51,7 @@ class RememberMeProvider extends AbstractProvider
      *
      * @return array
      */
-    public function getTokenClassNames()
+    public function getTokenClassNames(): array
     {
         return [RememberMe::class];
     }
@@ -61,6 +62,8 @@ class RememberMeProvider extends AbstractProvider
      *
      * @param TokenInterface $authenticationToken The token to be authenticated
      * @return void
+     * @throws InvalidArgumentForHashGenerationException
+     * @throws InvalidAuthenticationStatusException
      * @throws UnsupportedAuthenticationTokenException
      */
     public function authenticate(TokenInterface $authenticationToken)
@@ -76,6 +79,7 @@ class RememberMeProvider extends AbstractProvider
      * @param RememberMe $token
      * @throws InvalidArgumentForHashGenerationException
      * @throws InvalidAuthenticationStatusException
+     * @throws Exception
      */
     protected function authenticateRememberMeToken(RememberMe $token)
     {
@@ -86,10 +90,10 @@ class RememberMeProvider extends AbstractProvider
         }
         // Don't be surprised by the hard-coded "jwt". That is *not* the secret key of the JWT. HashService::generateHmac() uses the encryption key of this installation
         $jwtKey = $this->hashService->generateHmac('jwt');
-        $jwtPayload = null;
+
         try {
             $jwtPayload = (array)JwtService::decode($credentials['jwt'], $jwtKey, ['HS256']);
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->throwableStorage->logThrowable($exception);
             $token->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
             return;
@@ -104,13 +108,13 @@ class RememberMeProvider extends AbstractProvider
         $account->setAuthenticationProviderName($this->name);
 
         if (empty($this->rememberMeAuthenticationProcessorClassName)) {
-            throw new \Exception('Setting CRON.RememberMe.rememberMeAuthenticationProcessorClassName is not set.');
+            throw new Exception('Setting CRON.RememberMe.rememberMeAuthenticationProcessorClassName is not set.');
         }
 
         $rememberMeAuthenticationProcessor = new $this->rememberMeAuthenticationProcessorClassName();
 
         if (!$rememberMeAuthenticationProcessor instanceof RememberMeAuthenticationProcessorInterface) {
-            throw new \Exception(sprintf('Class "%s" should implement RememberMeAuthenticationProcessorInterface but does not.', $this->rememberMeAuthenticationProcessorClassName));
+            throw new Exception(sprintf('Class "%s" should implement RememberMeAuthenticationProcessorInterface but does not.', $this->rememberMeAuthenticationProcessorClassName));
         }
 
         $rememberMeAuthenticationProcessor->process($account, $token, $jwtPayload);

--- a/Classes/Security/Authentication/RememberMeProvider.php
+++ b/Classes/Security/Authentication/RememberMeProvider.php
@@ -5,7 +5,7 @@ namespace CRON\RememberMe\Security\Authentication;
 use Neos\Flow\Annotations as Flow;
 use CRON\RememberMe\Security\Authentication\Token\RememberMe;
 use Firebase\JWT\JWT as JwtService;
-use Neos\Flow\Log\SystemLoggerInterface;
+use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Authentication\Provider\AbstractProvider;
 use Neos\Flow\Security\Authentication\TokenInterface;
@@ -27,10 +27,17 @@ class RememberMeProvider extends AbstractProvider
     protected $hashService;
 
     /**
-     * @Flow\Inject
-     * @var SystemLoggerInterface
+     * @var ThrowableStorageInterface
      */
-    protected $systemLogger;
+    private $throwableStorage;
+
+    /**
+     * @param ThrowableStorageInterface $throwableStorage
+     */
+    public function injectThrowableStorage(ThrowableStorageInterface $throwableStorage)
+    {
+        $this->throwableStorage = $throwableStorage;
+    }
 
     /**
      * @Flow\InjectConfiguration(path="rememberMeAuthenticationProcessorClassName")
@@ -83,7 +90,7 @@ class RememberMeProvider extends AbstractProvider
         try {
             $jwtPayload = (array)JwtService::decode($credentials['jwt'], $jwtKey, ['HS256']);
         } catch (\Exception $exception) {
-            $this->systemLogger->logException($exception);
+            $this->throwableStorage->logThrowable($exception);
             $token->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
             return;
         }

--- a/Classes/Security/Authentication/Token/RememberMe.php
+++ b/Classes/Security/Authentication/Token/RememberMe.php
@@ -33,8 +33,9 @@ class RememberMe extends AbstractToken
      */
     public function updateCredentials(ActionRequest $actionRequest)
     {
-        $jwtCookie = $actionRequest->getHttpRequest()->getCookie($this->cookie['name']);
-        if ($jwtCookie === null || empty($jwtCookie->getValue())) {
+        $cookieParams = $actionRequest->getHttpRequest()->getCookieParams();
+
+        if (isset($cookieParams[$this->cookie['name']]) || empty($cookieParams[$this->cookie['name']])) {
             $this->setAuthenticationStatus(self::NO_CREDENTIALS_GIVEN);
             return false;
         }
@@ -43,7 +44,7 @@ class RememberMe extends AbstractToken
         // this will avoid re-authentication with every request.
         // Flow keeps this token with status AUTHENTICATION_SUCCESSFUL in the session after successful authentication.
         if ($this->getAuthenticationStatus() !== self::AUTHENTICATION_SUCCESSFUL) {
-            $this->credentials['jwt'] = $jwtCookie->getValue();
+            $this->credentials['jwt'] = $cookieParams[$this->cookie['name']];
             $this->setAuthenticationStatus(self::AUTHENTICATION_NEEDED);
         }
     }

--- a/Classes/Security/Authentication/Token/RememberMe.php
+++ b/Classes/Security/Authentication/Token/RememberMe.php
@@ -36,7 +36,9 @@ class RememberMe extends AbstractToken
     {
         $cookieParams = $actionRequest->getHttpRequest()->getCookieParams();
 
-        if (isset($cookieParams[$this->cookie['name']]) || empty($cookieParams[$this->cookie['name']])) {
+        $cookieValue = $cookieParams[$this->cookie['name']] ?? null;
+
+        if (empty($cookieValue)) {
             $this->setAuthenticationStatus(self::NO_CREDENTIALS_GIVEN);
             return false;
         }
@@ -45,7 +47,7 @@ class RememberMe extends AbstractToken
         // this will avoid re-authentication with every request.
         // Flow keeps this token with status AUTHENTICATION_SUCCESSFUL in the session after successful authentication.
         if ($this->getAuthenticationStatus() !== self::AUTHENTICATION_SUCCESSFUL) {
-            $this->credentials['jwt'] = $cookieParams[$this->cookie['name']];
+            $this->credentials['jwt'] = $cookieValue;
             $this->setAuthenticationStatus(self::AUTHENTICATION_NEEDED);
         }
     }

--- a/Classes/Security/Authentication/Token/RememberMe.php
+++ b/Classes/Security/Authentication/Token/RememberMe.php
@@ -5,6 +5,7 @@ namespace CRON\RememberMe\Security\Authentication\Token;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Authentication\Token\AbstractToken;
+use Neos\Flow\Security\Exception\InvalidAuthenticationStatusException;
 
 /**
  * An authentication token used to fetch JWT credentials from a cookie
@@ -29,7 +30,7 @@ class RememberMe extends AbstractToken
     /**
      * @param ActionRequest $actionRequest The current action request
      * @return boolean
-     * @throws \Neos\Flow\Security\Exception\InvalidAuthenticationStatusException
+     * @throws InvalidAuthenticationStatusException
      */
     public function updateCredentials(ActionRequest $actionRequest)
     {

--- a/Classes/Security/Authentication/Token/UsernamePasswordWithRememberMe.php
+++ b/Classes/Security/Authentication/Token/UsernamePasswordWithRememberMe.php
@@ -3,7 +3,6 @@
 namespace CRON\RememberMe\Security\Authentication\Token;
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Http\Request as HttpRequest;
 use Neos\Flow\Security\Authentication\Token\AbstractToken;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Exception\InvalidAuthenticationStatusException;
@@ -49,7 +48,7 @@ class UsernamePasswordWithRememberMe extends AbstractToken
             return false;
         }
         $parentRequest = $referringRequest->getParentRequest();
-        if (!$parentRequest instanceof ActionRequest && !$parentRequest instanceof HttpRequest) {
+        if (!$parentRequest instanceof ActionRequest) {
             return false;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "type": "neos-package",
   "license": "proprietary",
   "require": {
-    "neos/flow": "*",
-    "neos/neos": "*",
+    "neos/neos": "^5.0",
+    "neos/flow": "^6.0",
     "firebase/php-jwt": "^5.2"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "type": "neos-package",
   "license": "proprietary",
   "require": {
-    "neos/flow": "^5.3",
-    "neos/neos": "^4.3",
+    "neos/flow": "*",
+    "neos/neos": "*",
     "firebase/php-jwt": "^5.2"
   },
   "autoload": {


### PR DESCRIPTION
This PR makes this package compatible for Neos ^5.0 (Flow ^6.0).

The new version 2.0.0 will be added because this PR adds breaking changes for Neos 4.3 (Flow 5.3).
The version 1.0.0 will remain for compatibility with Neos 4.3 (Flow 5.3).

See https://github.com/cron-eu/neos-rememberme/wiki/Version-History .

This PR also fixes most of the (weak) warnings.